### PR TITLE
Fix image offset for iOS 12+

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const convertCpbitmapToPng = async (inpFileName, outFileName) => {
     const image = await new Jimp(width, height, 0x000000FF)
 
     const calcOffsetInCpbmp = (x, y, width) => {
-        const lineSize = Math.ceil(width / 8) * 8
+        const lineSize = Math.ceil(width / 16) * 16
         return x * 4 + y * lineSize * 4
     }
 


### PR DESCRIPTION
This pull request fixes the image offset, based on the work in the [cpbitmap.github.io](https://github.com/cpbitmap/cpbitmap.github.io/blob/main/pages/index.tsx#L13-L40) project.

Before:
<img src="https://user-images.githubusercontent.com/2276355/190826979-4e3bd00d-fd7a-47f2-8513-565baaef1b9b.png" width="250">

After:
<img src="https://user-images.githubusercontent.com/2276355/190826983-5bd1b748-0327-4d4c-b375-8b17f6170bb6.png" width="250">